### PR TITLE
Fix typo on README.md and replace jupyter lab for jupyter notebook

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The [Harmonica tutorial at Transform 21](http://schedule.softwareunderground.org
 
 Instructors:
 [Santiago Soler](https://santisoler.github.io)<sup>1,2</sup>,
-[Andra Balza Morales](https://www.andreabalza.com/)<sup>3</sup> and
+[Andrea Balza Morales](https://www.andreabalza.com/)<sup>3</sup> and
 [Agustina Pesce](https://aguspesce.github.io/)<sup>1,2</sup>
 
 > <sup>1</sup> CONICET, Argentina
@@ -75,7 +75,7 @@ There are a few things you'll need to follow the tutorial:
 
 1. A working Python installation (Anaconda or Miniconda)
 2. The Harmonica tutorial *conda environment* installed
-3. A web browser that works with JupyterLab
+3. A web browser that works with Jupyter notebooks
    (basically anything except Internet Explorer)
 
 To get things setup, please do the following.


### PR DESCRIPTION
edit my name and remove jupyter lab since step 4 says jupyter notebook.

<!--
Please describe changes proposed and WHY you made them. If fixing an issue,
include the text "Fixes #XXX" (replace XXX by the issue number. GitHub will
automatically close it when this gets merged.
-->





**Reminders**:

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst` and the base `__init__.py` file for the package.
- [ ] Write detailed docstrings for all functions/classes/methods. It often helps to design better code if you write the docstrings first.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
- [ ] Add your full name, affiliation, and [ORCID](https://orcid.org) (optional) to the `AUTHORS.md` file (if you haven't already) in case you'd like to be listed as an author on the [Zenodo](https://zenodo.org/communities/fatiando) archive of the next release.
