### PR TITLE
Remove unneeded .values from notebooks

### DIFF
--- a/process-gravity.ipynb
+++ b/process-gravity.ipynb
@@ -2,6 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "43212ab1",
    "metadata": {},
    "source": [
     "# Processing gravity data with Harmonica\n",
@@ -21,6 +22,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "a30fca93",
    "metadata": {},
    "source": [
     "## Study Area\n",
@@ -38,6 +40,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "1619af3b",
    "metadata": {},
    "source": [
     "## Import libraries"
@@ -46,6 +49,7 @@
   {
    "cell_type": "code",
    "execution_count": 1,
+   "id": "ed97064f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -61,6 +65,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "71c69209",
    "metadata": {},
    "source": [
     "Increase the size of the matplotlib figures (this is not necessary, it's only for the live coding presentation)"
@@ -69,6 +74,7 @@
   {
    "cell_type": "code",
    "execution_count": 2,
+   "id": "1445882a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -78,6 +84,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "f5f7ef12",
    "metadata": {},
    "source": [
     "## Load South Africa gravity data"
@@ -86,6 +93,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
+   "id": "180f1c6f",
    "metadata": {},
    "outputs": [
     {
@@ -227,6 +235,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "2fb39f77",
    "metadata": {},
    "source": [
     "Plot the data in longitude and latitude (geographic coordinates):"
@@ -235,6 +244,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
+   "id": "f5fdf936",
    "metadata": {},
    "outputs": [
     {
@@ -259,6 +269,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "05495191",
    "metadata": {},
    "source": [
     "When we plot data in geographic coordinates, the map looks distorted, we need to project it to plain coordinates."
@@ -266,6 +277,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "5ff92855",
    "metadata": {},
    "source": [
     "## Project data to plain coordinates\n",
@@ -276,6 +288,7 @@
   {
    "cell_type": "code",
    "execution_count": 5,
+   "id": "e340530b",
    "metadata": {},
    "outputs": [
     {
@@ -449,6 +462,7 @@
   {
    "cell_type": "code",
    "execution_count": 6,
+   "id": "2234d7f2",
    "metadata": {},
    "outputs": [
     {
@@ -474,6 +488,7 @@
   {
    "cell_type": "code",
    "execution_count": 7,
+   "id": "cb05ea14",
    "metadata": {},
    "outputs": [
     {
@@ -498,6 +513,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "a2ef7057",
    "metadata": {},
    "source": [
     "## Cut the dataset into a smaller region"
@@ -505,6 +521,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "5de0336b",
    "metadata": {},
    "source": [
     "We will cut the dataset into a smaller region using **[Verde](https://www.fatiando.org/verde)**."
@@ -513,6 +530,7 @@
   {
    "cell_type": "code",
    "execution_count": 8,
+   "id": "4c4464b8",
    "metadata": {},
    "outputs": [
     {
@@ -685,6 +703,7 @@
   {
    "cell_type": "code",
    "execution_count": 9,
+   "id": "babccf0c",
    "metadata": {},
    "outputs": [
     {
@@ -709,6 +728,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "ea7d492a",
    "metadata": {},
    "source": [
     "## Compute gravity disturbance\n",
@@ -727,6 +747,7 @@
   {
    "cell_type": "code",
    "execution_count": 10,
+   "id": "79dc1e36",
    "metadata": {},
    "outputs": [
     {
@@ -915,7 +936,7 @@
     "ell = bl.WGS84\n",
     "\n",
     "# Calculate the gravity disturbance:\n",
-    "gravity_disturbance = data.gravity.values - ell.normal_gravity(data.latitude.values, data.elevation.values)\n",
+    "gravity_disturbance = data.gravity - ell.normal_gravity(data.latitude, data.elevation)\n",
     "# Add the gravity_disturbance to the dataset as a columne: \n",
     "data = data.assign(gravity_disturbance=gravity_disturbance)\n",
     "data"
@@ -924,6 +945,7 @@
   {
    "cell_type": "code",
    "execution_count": 11,
+   "id": "8ab9c921",
    "metadata": {},
    "outputs": [
     {
@@ -948,6 +970,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "db0ec62c",
    "metadata": {},
    "source": [
     "## Compute Bouguer gravity disturbance\n",
@@ -968,6 +991,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "a0c9d406",
    "metadata": {},
    "source": [
     "### Load a DEM of South Africa (ETOPO1)"
@@ -976,6 +1000,7 @@
   {
    "cell_type": "code",
    "execution_count": 12,
+   "id": "c94bb77d",
    "metadata": {},
    "outputs": [
     {
@@ -1344,14 +1369,14 @@
        "    title:        ETOPO1 Bedrock Relief\n",
        "    GMT_version:  4.4.0\n",
        "    node_offset:  0\n",
-       "    doi:          10.7289/V5C8276M</pre><div class='xr-wrap' hidden><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-162a07a1-edd9-4b5d-b658-cef8648cc4b2' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-162a07a1-edd9-4b5d-b658-cef8648cc4b2' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>latitude</span>: 240</li><li><span class='xr-has-index'>longitude</span>: 419</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-5151dec8-3338-40a9-8117-1791248647cc' class='xr-section-summary-in' type='checkbox'  checked><label for='section-5151dec8-3338-40a9-8117-1791248647cc' class='xr-section-summary' >Coordinates: <span>(2)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>longitude</span></div><div class='xr-var-dims'>(longitude)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>25.02 25.03 25.05 ... 31.97 31.98</div><input id='attrs-848f7bec-ac2c-4b07-9e71-93ebacd4f5e2' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-848f7bec-ac2c-4b07-9e71-93ebacd4f5e2' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-eff02ba8-d8ba-4b12-91ce-31e1a5b50e9e' class='xr-var-data-in' type='checkbox'><label for='data-eff02ba8-d8ba-4b12-91ce-31e1a5b50e9e' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>Longitude</dd><dt><span>actual_range :</span></dt><dd>[-180.  180.]</dd><dt><span>units :</span></dt><dd>degrees_east</dd></dl></div><div class='xr-var-data'><pre>array([25.016667, 25.033333, 25.05    , ..., 31.95    , 31.966667, 31.983333])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>latitude</span></div><div class='xr-var-dims'>(latitude)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>-27.0 -26.98 ... -23.03 -23.02</div><input id='attrs-51d3128b-7cc4-4f28-89ae-38ffb22a581f' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-51d3128b-7cc4-4f28-89ae-38ffb22a581f' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-a13da7bc-bb4f-4965-bb2e-f14c0b2eb707' class='xr-var-data-in' type='checkbox'><label for='data-a13da7bc-bb4f-4965-bb2e-f14c0b2eb707' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>Latitude</dd><dt><span>actual_range :</span></dt><dd>[-90.  90.]</dd><dt><span>units :</span></dt><dd>degrees_north</dd></dl></div><div class='xr-var-data'><pre>array([-27.      , -26.983333, -26.966667, ..., -23.05    , -23.033333,\n",
-       "       -23.016667])</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-ec3c5c30-dca0-4878-aa64-45a5732a0c1c' class='xr-section-summary-in' type='checkbox'  checked><label for='section-ec3c5c30-dca0-4878-aa64-45a5732a0c1c' class='xr-section-summary' >Data variables: <span>(1)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>bedrock</span></div><div class='xr-var-dims'>(latitude, longitude)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>1.257e+03 1.26e+03 ... 241.0 238.0</div><input id='attrs-9e8fe793-3c02-4fa1-9c19-d7731d9e4002' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-9e8fe793-3c02-4fa1-9c19-d7731d9e4002' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-f156e90a-07b0-4c40-8768-a00a04e5b37b' class='xr-var-data-in' type='checkbox'><label for='data-f156e90a-07b0-4c40-8768-a00a04e5b37b' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>Bedrock relief</dd><dt><span>actual_range :</span></dt><dd>[-10898.   8271.]</dd><dt><span>units :</span></dt><dd>meters</dd><dt><span>vertical_datum :</span></dt><dd>sea level</dd><dt><span>datum :</span></dt><dd>WGS84</dd></dl></div><div class='xr-var-data'><pre>array([[1257., 1260., 1266., ...,  195.,  201.,  425.],\n",
+       "    doi:          10.7289/V5C8276M</pre><div class='xr-wrap' hidden><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-cf13a6f5-ddf3-4e23-924b-c1b1bcea34bf' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-cf13a6f5-ddf3-4e23-924b-c1b1bcea34bf' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>latitude</span>: 240</li><li><span class='xr-has-index'>longitude</span>: 419</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-1bb6dba7-901a-4fe1-b511-0b82fd22a538' class='xr-section-summary-in' type='checkbox'  checked><label for='section-1bb6dba7-901a-4fe1-b511-0b82fd22a538' class='xr-section-summary' >Coordinates: <span>(2)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>longitude</span></div><div class='xr-var-dims'>(longitude)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>25.02 25.03 25.05 ... 31.97 31.98</div><input id='attrs-fd76e2d3-bf8a-40c1-a1a1-cc3b929b9e82' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-fd76e2d3-bf8a-40c1-a1a1-cc3b929b9e82' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-eec2beff-a76c-4045-86dd-3a0717ec4b8b' class='xr-var-data-in' type='checkbox'><label for='data-eec2beff-a76c-4045-86dd-3a0717ec4b8b' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>Longitude</dd><dt><span>actual_range :</span></dt><dd>[-180.  180.]</dd><dt><span>units :</span></dt><dd>degrees_east</dd></dl></div><div class='xr-var-data'><pre>array([25.016667, 25.033333, 25.05    , ..., 31.95    , 31.966667, 31.983333])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>latitude</span></div><div class='xr-var-dims'>(latitude)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>-27.0 -26.98 ... -23.03 -23.02</div><input id='attrs-a2bb033c-83a5-43c8-9f5f-0119c05d3c6e' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-a2bb033c-83a5-43c8-9f5f-0119c05d3c6e' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-dc19d61f-e534-41d0-be30-6ab3f2531c6c' class='xr-var-data-in' type='checkbox'><label for='data-dc19d61f-e534-41d0-be30-6ab3f2531c6c' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>Latitude</dd><dt><span>actual_range :</span></dt><dd>[-90.  90.]</dd><dt><span>units :</span></dt><dd>degrees_north</dd></dl></div><div class='xr-var-data'><pre>array([-27.      , -26.983333, -26.966667, ..., -23.05    , -23.033333,\n",
+       "       -23.016667])</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-76cdb1ca-d358-46f4-a0ab-e0dc600a5a2c' class='xr-section-summary-in' type='checkbox'  checked><label for='section-76cdb1ca-d358-46f4-a0ab-e0dc600a5a2c' class='xr-section-summary' >Data variables: <span>(1)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>bedrock</span></div><div class='xr-var-dims'>(latitude, longitude)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>1.257e+03 1.26e+03 ... 241.0 238.0</div><input id='attrs-2d600324-91b6-4e6a-af57-2f81eeaf4f56' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-2d600324-91b6-4e6a-af57-2f81eeaf4f56' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-5a13d3c3-805c-4889-b592-24daf7c1e6dd' class='xr-var-data-in' type='checkbox'><label for='data-5a13d3c3-805c-4889-b592-24daf7c1e6dd' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>Bedrock relief</dd><dt><span>actual_range :</span></dt><dd>[-10898.   8271.]</dd><dt><span>units :</span></dt><dd>meters</dd><dt><span>vertical_datum :</span></dt><dd>sea level</dd><dt><span>datum :</span></dt><dd>WGS84</dd></dl></div><div class='xr-var-data'><pre>array([[1257., 1260., 1266., ...,  195.,  201.,  425.],\n",
        "       [1245., 1254., 1261., ...,  206.,  215.,  375.],\n",
        "       [1256., 1258., 1268., ...,  200.,  232.,  300.],\n",
        "       ...,\n",
        "       [1029., 1031., 1033., ...,  248.,  242.,  238.],\n",
        "       [1029., 1031., 1033., ...,  247.,  242.,  237.],\n",
-       "       [1028., 1030., 1032., ...,  247.,  241.,  238.]])</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-ec8295fd-03ba-4550-b2f5-9f97571e73ab' class='xr-section-summary-in' type='checkbox'  checked><label for='section-ec8295fd-03ba-4550-b2f5-9f97571e73ab' class='xr-section-summary' >Attributes: <span>(5)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>Conventions :</span></dt><dd>COARDS/CF-1.0</dd><dt><span>title :</span></dt><dd>ETOPO1 Bedrock Relief</dd><dt><span>GMT_version :</span></dt><dd>4.4.0</dd><dt><span>node_offset :</span></dt><dd>0</dd><dt><span>doi :</span></dt><dd>10.7289/V5C8276M</dd></dl></div></li></ul></div></div>"
+       "       [1028., 1030., 1032., ...,  247.,  241.,  238.]])</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-59d93a84-7d3a-425c-bbcd-0c24201b4cc0' class='xr-section-summary-in' type='checkbox'  checked><label for='section-59d93a84-7d3a-425c-bbcd-0c24201b4cc0' class='xr-section-summary' >Attributes: <span>(5)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>Conventions :</span></dt><dd>COARDS/CF-1.0</dd><dt><span>title :</span></dt><dd>ETOPO1 Bedrock Relief</dd><dt><span>GMT_version :</span></dt><dd>4.4.0</dd><dt><span>node_offset :</span></dt><dd>0</dd><dt><span>doi :</span></dt><dd>10.7289/V5C8276M</dd></dl></div></li></ul></div></div>"
       ],
       "text/plain": [
        "<xarray.Dataset>\n",
@@ -1385,6 +1410,7 @@
   {
    "cell_type": "code",
    "execution_count": 13,
+   "id": "a37bb65d",
    "metadata": {},
    "outputs": [
     {
@@ -1757,14 +1783,14 @@
        "    actual_range:    [-10898.   8271.]\n",
        "    units:           meters\n",
        "    vertical_datum:  sea level\n",
-       "    datum:           WGS84</pre><div class='xr-wrap' hidden><div class='xr-header'><div class='xr-obj-type'>xarray.DataArray</div><div class='xr-array-name'>'bedrock'</div><ul class='xr-dim-list'><li><span class='xr-has-index'>latitude</span>: 240</li><li><span class='xr-has-index'>longitude</span>: 419</li></ul></div><ul class='xr-sections'><li class='xr-section-item'><div class='xr-array-wrap'><input id='section-4073c55c-3aef-4a21-9ff2-b8182ed248aa' class='xr-array-in' type='checkbox' checked><label for='section-4073c55c-3aef-4a21-9ff2-b8182ed248aa' title='Show/hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-array-preview xr-preview'><span>1.257e+03 1.26e+03 1.266e+03 1.271e+03 ... 253.0 247.0 241.0 238.0</span></div><div class='xr-array-data'><pre>array([[1257., 1260., 1266., ...,  195.,  201.,  425.],\n",
+       "    datum:           WGS84</pre><div class='xr-wrap' hidden><div class='xr-header'><div class='xr-obj-type'>xarray.DataArray</div><div class='xr-array-name'>'bedrock'</div><ul class='xr-dim-list'><li><span class='xr-has-index'>latitude</span>: 240</li><li><span class='xr-has-index'>longitude</span>: 419</li></ul></div><ul class='xr-sections'><li class='xr-section-item'><div class='xr-array-wrap'><input id='section-cbc95a2a-92ae-41b7-a3ad-2c65c60da3d4' class='xr-array-in' type='checkbox' checked><label for='section-cbc95a2a-92ae-41b7-a3ad-2c65c60da3d4' title='Show/hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-array-preview xr-preview'><span>1.257e+03 1.26e+03 1.266e+03 1.271e+03 ... 253.0 247.0 241.0 238.0</span></div><div class='xr-array-data'><pre>array([[1257., 1260., 1266., ...,  195.,  201.,  425.],\n",
        "       [1245., 1254., 1261., ...,  206.,  215.,  375.],\n",
        "       [1256., 1258., 1268., ...,  200.,  232.,  300.],\n",
        "       ...,\n",
        "       [1029., 1031., 1033., ...,  248.,  242.,  238.],\n",
        "       [1029., 1031., 1033., ...,  247.,  242.,  237.],\n",
-       "       [1028., 1030., 1032., ...,  247.,  241.,  238.]])</pre></div></div></li><li class='xr-section-item'><input id='section-82d18385-83f3-46c4-8b33-87cdf3d7ba8a' class='xr-section-summary-in' type='checkbox'  checked><label for='section-82d18385-83f3-46c4-8b33-87cdf3d7ba8a' class='xr-section-summary' >Coordinates: <span>(2)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>longitude</span></div><div class='xr-var-dims'>(longitude)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>25.02 25.03 25.05 ... 31.97 31.98</div><input id='attrs-5596a368-22c2-4bd1-a56d-205f68b19aed' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-5596a368-22c2-4bd1-a56d-205f68b19aed' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-bc4f64d5-bb51-4aa8-83fb-49dea8857f70' class='xr-var-data-in' type='checkbox'><label for='data-bc4f64d5-bb51-4aa8-83fb-49dea8857f70' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>Longitude</dd><dt><span>actual_range :</span></dt><dd>[-180.  180.]</dd><dt><span>units :</span></dt><dd>degrees_east</dd></dl></div><div class='xr-var-data'><pre>array([25.016667, 25.033333, 25.05    , ..., 31.95    , 31.966667, 31.983333])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>latitude</span></div><div class='xr-var-dims'>(latitude)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>-27.0 -26.98 ... -23.03 -23.02</div><input id='attrs-7da06cf4-fffe-467e-aa9f-b716f5e77338' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-7da06cf4-fffe-467e-aa9f-b716f5e77338' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-0a1321dd-1f94-4bb9-93ad-a97e727a6a6c' class='xr-var-data-in' type='checkbox'><label for='data-0a1321dd-1f94-4bb9-93ad-a97e727a6a6c' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>Latitude</dd><dt><span>actual_range :</span></dt><dd>[-90.  90.]</dd><dt><span>units :</span></dt><dd>degrees_north</dd></dl></div><div class='xr-var-data'><pre>array([-27.      , -26.983333, -26.966667, ..., -23.05    , -23.033333,\n",
-       "       -23.016667])</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-72ff3f86-1c04-443f-8707-ef78ca8aed91' class='xr-section-summary-in' type='checkbox'  checked><label for='section-72ff3f86-1c04-443f-8707-ef78ca8aed91' class='xr-section-summary' >Attributes: <span>(5)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>Bedrock relief</dd><dt><span>actual_range :</span></dt><dd>[-10898.   8271.]</dd><dt><span>units :</span></dt><dd>meters</dd><dt><span>vertical_datum :</span></dt><dd>sea level</dd><dt><span>datum :</span></dt><dd>WGS84</dd></dl></div></li></ul></div></div>"
+       "       [1028., 1030., 1032., ...,  247.,  241.,  238.]])</pre></div></div></li><li class='xr-section-item'><input id='section-c826ffe8-0ff5-4861-bf1a-c2e965da34d4' class='xr-section-summary-in' type='checkbox'  checked><label for='section-c826ffe8-0ff5-4861-bf1a-c2e965da34d4' class='xr-section-summary' >Coordinates: <span>(2)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>longitude</span></div><div class='xr-var-dims'>(longitude)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>25.02 25.03 25.05 ... 31.97 31.98</div><input id='attrs-57cf9fec-e278-4d06-a924-d2259e67a7c9' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-57cf9fec-e278-4d06-a924-d2259e67a7c9' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-2140aa28-1a55-4f80-90f6-17a9bbda6def' class='xr-var-data-in' type='checkbox'><label for='data-2140aa28-1a55-4f80-90f6-17a9bbda6def' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>Longitude</dd><dt><span>actual_range :</span></dt><dd>[-180.  180.]</dd><dt><span>units :</span></dt><dd>degrees_east</dd></dl></div><div class='xr-var-data'><pre>array([25.016667, 25.033333, 25.05    , ..., 31.95    , 31.966667, 31.983333])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>latitude</span></div><div class='xr-var-dims'>(latitude)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>-27.0 -26.98 ... -23.03 -23.02</div><input id='attrs-2582efa8-0be4-4a7a-9e01-6b93c6b47961' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-2582efa8-0be4-4a7a-9e01-6b93c6b47961' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-97649a00-769c-404c-84ba-d1e45a8aaafa' class='xr-var-data-in' type='checkbox'><label for='data-97649a00-769c-404c-84ba-d1e45a8aaafa' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>Latitude</dd><dt><span>actual_range :</span></dt><dd>[-90.  90.]</dd><dt><span>units :</span></dt><dd>degrees_north</dd></dl></div><div class='xr-var-data'><pre>array([-27.      , -26.983333, -26.966667, ..., -23.05    , -23.033333,\n",
+       "       -23.016667])</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-94f4b3e6-8de8-4190-bf9c-a332944b6f9d' class='xr-section-summary-in' type='checkbox'  checked><label for='section-94f4b3e6-8de8-4190-bf9c-a332944b6f9d' class='xr-section-summary' >Attributes: <span>(5)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>Bedrock relief</dd><dt><span>actual_range :</span></dt><dd>[-10898.   8271.]</dd><dt><span>units :</span></dt><dd>meters</dd><dt><span>vertical_datum :</span></dt><dd>sea level</dd><dt><span>datum :</span></dt><dd>WGS84</dd></dl></div></li></ul></div></div>"
       ],
       "text/plain": [
        "<xarray.DataArray 'bedrock' (latitude: 240, longitude: 419)>\n",
@@ -1799,6 +1825,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "e5685bae",
    "metadata": {},
    "source": [
     "### Project the topography to plain coordinates"
@@ -1807,6 +1834,7 @@
   {
    "cell_type": "code",
    "execution_count": 14,
+   "id": "1919e716",
    "metadata": {},
    "outputs": [
     {
@@ -2181,7 +2209,7 @@
        "  * easting   (easting) float64 2.464e+06 2.466e+06 ... 3.148e+06 3.15e+06\n",
        "  * northing  (northing) float64 -2.746e+06 -2.745e+06 ... -2.318e+06 -2.316e+06\n",
        "Attributes:\n",
-       "    metadata:  Generated by Chain(steps=[(&#x27;mean&#x27;,\\n              BlockReduce(...</pre><div class='xr-wrap' hidden><div class='xr-header'><div class='xr-obj-type'>xarray.DataArray</div><div class='xr-array-name'>'bedrock'</div><ul class='xr-dim-list'><li><span class='xr-has-index'>northing</span>: 240</li><li><span class='xr-has-index'>easting</span>: 419</li></ul></div><ul class='xr-sections'><li class='xr-section-item'><div class='xr-array-wrap'><input id='section-55c88cc2-6d9c-4e2b-a9a3-728f5701609e' class='xr-array-in' type='checkbox' checked><label for='section-55c88cc2-6d9c-4e2b-a9a3-728f5701609e' title='Show/hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-array-preview xr-preview'><span>1.257e+03 1.26e+03 1.266e+03 1.271e+03 1.274e+03 ... nan nan nan nan</span></div><div class='xr-array-data'><pre>array([[1257.        , 1260.        , 1266.        , ...,  195.        ,\n",
+       "    metadata:  Generated by Chain(steps=[(&#x27;mean&#x27;,\\n              BlockReduce(...</pre><div class='xr-wrap' hidden><div class='xr-header'><div class='xr-obj-type'>xarray.DataArray</div><div class='xr-array-name'>'bedrock'</div><ul class='xr-dim-list'><li><span class='xr-has-index'>northing</span>: 240</li><li><span class='xr-has-index'>easting</span>: 419</li></ul></div><ul class='xr-sections'><li class='xr-section-item'><div class='xr-array-wrap'><input id='section-10c468dd-74bd-46f9-9bd5-d39e16d25c75' class='xr-array-in' type='checkbox' checked><label for='section-10c468dd-74bd-46f9-9bd5-d39e16d25c75' title='Show/hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-array-preview xr-preview'><span>1.257e+03 1.26e+03 1.266e+03 1.271e+03 1.274e+03 ... nan nan nan nan</span></div><div class='xr-array-data'><pre>array([[1257.        , 1260.        , 1266.        , ...,  195.        ,\n",
        "         201.        ,  425.        ],\n",
        "       [1245.19963571, 1254.09981785, 1261.08318154, ...,  205.8170006 ,\n",
        "         214.76709167,  375.83181545],\n",
@@ -2193,10 +2221,10 @@
        "       [1028.67199134, 1030.67199134, 1032.67199134, ...,  247.34398268,\n",
        "         241.90131312,  237.80956374],\n",
        "       [          nan,           nan,           nan, ...,           nan,\n",
-       "                  nan,           nan]])</pre></div></div></li><li class='xr-section-item'><input id='section-251ac4d3-4653-466e-a838-074f7f0455bd' class='xr-section-summary-in' type='checkbox'  checked><label for='section-251ac4d3-4653-466e-a838-074f7f0455bd' class='xr-section-summary' >Coordinates: <span>(2)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>easting</span></div><div class='xr-var-dims'>(easting)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>2.464e+06 2.466e+06 ... 3.15e+06</div><input id='attrs-d93ab0de-69c7-44df-a791-35f367798e3c' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-d93ab0de-69c7-44df-a791-35f367798e3c' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-3f9d2083-cd29-4011-869a-1a29d3ecf441' class='xr-var-data-in' type='checkbox'><label for='data-3f9d2083-cd29-4011-869a-1a29d3ecf441' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([2463914.915241, 2465556.430841, 2467197.94644 , ..., 3146785.404741,\n",
-       "       3148426.920341, 3150068.435941])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>northing</span></div><div class='xr-var-dims'>(northing)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>-2.746e+06 ... -2.316e+06</div><input id='attrs-c786d9c9-7fa6-49cc-ac9d-2629e3755e1e' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-c786d9c9-7fa6-49cc-ac9d-2629e3755e1e' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-2c744505-8772-4bd6-9011-d7879e5d5215' class='xr-var-data-in' type='checkbox'><label for='data-2c744505-8772-4bd6-9011-d7879e5d5215' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([-2746361.787553, -2744559.897412, -2742758.00727 , ..., -2319313.824056,\n",
-       "       -2317511.933914, -2315710.043773])</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-697b374b-fba2-4000-830a-214369318dbe' class='xr-section-summary-in' type='checkbox'  checked><label for='section-697b374b-fba2-4000-830a-214369318dbe' class='xr-section-summary' >Attributes: <span>(1)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>metadata :</span></dt><dd>Generated by Chain(steps=[(&#x27;mean&#x27;,\n",
-       "              BlockReduce(reduction=&lt;function mean at 0x7fb2e458b9d0&gt;,\n",
+       "                  nan,           nan]])</pre></div></div></li><li class='xr-section-item'><input id='section-eabe758c-3cf5-4e85-9411-7201455cf595' class='xr-section-summary-in' type='checkbox'  checked><label for='section-eabe758c-3cf5-4e85-9411-7201455cf595' class='xr-section-summary' >Coordinates: <span>(2)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>easting</span></div><div class='xr-var-dims'>(easting)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>2.464e+06 2.466e+06 ... 3.15e+06</div><input id='attrs-b30fc6f6-a34c-49e0-93fc-7eeca2268c18' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-b30fc6f6-a34c-49e0-93fc-7eeca2268c18' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-d7ad426c-ebc6-44a7-a082-b7f56b3a9204' class='xr-var-data-in' type='checkbox'><label for='data-d7ad426c-ebc6-44a7-a082-b7f56b3a9204' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([2463914.915241, 2465556.430841, 2467197.94644 , ..., 3146785.404741,\n",
+       "       3148426.920341, 3150068.435941])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>northing</span></div><div class='xr-var-dims'>(northing)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>-2.746e+06 ... -2.316e+06</div><input id='attrs-101c5d4c-5ba6-42c0-97bc-42a5e47df2f0' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-101c5d4c-5ba6-42c0-97bc-42a5e47df2f0' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-2caaeb28-a9ed-4bea-bb0d-7e6714531f4f' class='xr-var-data-in' type='checkbox'><label for='data-2caaeb28-a9ed-4bea-bb0d-7e6714531f4f' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([-2746361.787553, -2744559.897412, -2742758.00727 , ..., -2319313.824056,\n",
+       "       -2317511.933914, -2315710.043773])</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-2fdfdce5-bdf8-457e-adfa-9fc4b5d88334' class='xr-section-summary-in' type='checkbox'  checked><label for='section-2fdfdce5-bdf8-457e-adfa-9fc4b5d88334' class='xr-section-summary' >Attributes: <span>(1)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>metadata :</span></dt><dd>Generated by Chain(steps=[(&#x27;mean&#x27;,\n",
+       "              BlockReduce(reduction=&lt;function mean at 0x7fb6d434caf0&gt;,\n",
        "                          region=(2463914.915240965, 3150068.435940981,\n",
        "                                  -2746361.7875529216, -2315710.043773086),\n",
        "                          spacing=(1801.890141338225, 1641.515599760804))),\n",
@@ -2238,6 +2266,7 @@
   {
    "cell_type": "code",
    "execution_count": 15,
+   "id": "b9ccfa15",
    "metadata": {},
    "outputs": [
     {
@@ -2261,6 +2290,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "f9b376e7",
    "metadata": {},
    "source": [
     "### Model topography with prisms\n",
@@ -2271,6 +2301,7 @@
   {
    "cell_type": "code",
    "execution_count": 16,
+   "id": "f1f87f94",
    "metadata": {},
    "outputs": [
     {
@@ -2638,9 +2669,9 @@
        "    density   (northing, easting) float64 2.67e+03 2.67e+03 ... 2.67e+03\n",
        "Attributes:\n",
        "    coords_units:      meters\n",
-       "    properties_units:  SI</pre><div class='xr-wrap' hidden><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-01eafc05-91ea-4666-a8c4-fd5f89ae0326' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-01eafc05-91ea-4666-a8c4-fd5f89ae0326' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>easting</span>: 419</li><li><span class='xr-has-index'>northing</span>: 240</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-e43995e7-712c-4116-97eb-7d3970c88291' class='xr-section-summary-in' type='checkbox'  checked><label for='section-e43995e7-712c-4116-97eb-7d3970c88291' class='xr-section-summary' >Coordinates: <span>(4)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>easting</span></div><div class='xr-var-dims'>(easting)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>2.464e+06 2.466e+06 ... 3.15e+06</div><input id='attrs-a97b6c60-2a2c-4f4b-9a42-7e464e0e6bfc' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-a97b6c60-2a2c-4f4b-9a42-7e464e0e6bfc' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-2294e704-e74b-482c-8de7-148f6ab7c2d7' class='xr-var-data-in' type='checkbox'><label for='data-2294e704-e74b-482c-8de7-148f6ab7c2d7' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([2463914.915241, 2465556.430841, 2467197.94644 , ..., 3146785.404741,\n",
-       "       3148426.920341, 3150068.435941])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>northing</span></div><div class='xr-var-dims'>(northing)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>-2.746e+06 ... -2.316e+06</div><input id='attrs-c43a1a92-8d9d-4402-8a9b-865db9ba98df' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-c43a1a92-8d9d-4402-8a9b-865db9ba98df' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-0ca59c3b-b77f-4094-bb58-cecf410a18ec' class='xr-var-data-in' type='checkbox'><label for='data-0ca59c3b-b77f-4094-bb58-cecf410a18ec' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([-2746361.787553, -2744559.897412, -2742758.00727 , ..., -2319313.824056,\n",
-       "       -2317511.933914, -2315710.043773])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>top</span></div><div class='xr-var-dims'>(northing, easting)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>1.257e+03 1.26e+03 ... nan nan</div><input id='attrs-7354f2f6-997e-4993-aab3-6cef92c626db' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-7354f2f6-997e-4993-aab3-6cef92c626db' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-994b2a66-552d-4baa-ba6b-2ed4ab37e75d' class='xr-var-data-in' type='checkbox'><label for='data-994b2a66-552d-4baa-ba6b-2ed4ab37e75d' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([[1257.        , 1260.        , 1266.        , ...,  195.        ,\n",
+       "    properties_units:  SI</pre><div class='xr-wrap' hidden><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-1a732118-f2b5-4b13-b714-b11101d60dae' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-1a732118-f2b5-4b13-b714-b11101d60dae' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>easting</span>: 419</li><li><span class='xr-has-index'>northing</span>: 240</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-99f2a948-9861-4adb-acc0-14b1dff14134' class='xr-section-summary-in' type='checkbox'  checked><label for='section-99f2a948-9861-4adb-acc0-14b1dff14134' class='xr-section-summary' >Coordinates: <span>(4)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>easting</span></div><div class='xr-var-dims'>(easting)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>2.464e+06 2.466e+06 ... 3.15e+06</div><input id='attrs-07e7f511-02e2-4686-beae-e7085a361ca6' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-07e7f511-02e2-4686-beae-e7085a361ca6' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-b4342402-3d6a-42e0-bc42-ee874acb9236' class='xr-var-data-in' type='checkbox'><label for='data-b4342402-3d6a-42e0-bc42-ee874acb9236' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([2463914.915241, 2465556.430841, 2467197.94644 , ..., 3146785.404741,\n",
+       "       3148426.920341, 3150068.435941])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>northing</span></div><div class='xr-var-dims'>(northing)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>-2.746e+06 ... -2.316e+06</div><input id='attrs-f3d81d83-95bd-429e-af81-5e708448960e' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-f3d81d83-95bd-429e-af81-5e708448960e' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-5ab2dfb1-a1c9-4eaf-ae81-76e71b5ddb23' class='xr-var-data-in' type='checkbox'><label for='data-5ab2dfb1-a1c9-4eaf-ae81-76e71b5ddb23' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([-2746361.787553, -2744559.897412, -2742758.00727 , ..., -2319313.824056,\n",
+       "       -2317511.933914, -2315710.043773])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>top</span></div><div class='xr-var-dims'>(northing, easting)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>1.257e+03 1.26e+03 ... nan nan</div><input id='attrs-d4d98e1f-74a4-4b19-84f7-06119538decb' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-d4d98e1f-74a4-4b19-84f7-06119538decb' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-7c7014bb-4a54-42b7-8e67-c29b2ba72031' class='xr-var-data-in' type='checkbox'><label for='data-7c7014bb-4a54-42b7-8e67-c29b2ba72031' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([[1257.        , 1260.        , 1266.        , ...,  195.        ,\n",
        "         201.        ,  425.        ],\n",
        "       [1245.19963571, 1254.09981785, 1261.08318154, ...,  205.8170006 ,\n",
        "         214.76709167,  375.83181545],\n",
@@ -2652,19 +2683,19 @@
        "       [1028.67199134, 1030.67199134, 1032.67199134, ...,  247.34398268,\n",
        "         241.90131312,  237.80956374],\n",
        "       [          nan,           nan,           nan, ...,           nan,\n",
-       "                  nan,           nan]])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>bottom</span></div><div class='xr-var-dims'>(northing, easting)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>0.0 0.0 0.0 0.0 ... 0.0 0.0 0.0 0.0</div><input id='attrs-2aa17a75-9e10-4856-8f02-0ea188e89c81' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-2aa17a75-9e10-4856-8f02-0ea188e89c81' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-2835284b-5f5f-46b9-829b-2c26f81f283d' class='xr-var-data-in' type='checkbox'><label for='data-2835284b-5f5f-46b9-829b-2c26f81f283d' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([[0., 0., 0., ..., 0., 0., 0.],\n",
+       "                  nan,           nan]])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>bottom</span></div><div class='xr-var-dims'>(northing, easting)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>0.0 0.0 0.0 0.0 ... 0.0 0.0 0.0 0.0</div><input id='attrs-094cd554-b0b7-469e-8b0a-5956dc695e87' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-094cd554-b0b7-469e-8b0a-5956dc695e87' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-f4dfe1b6-621f-434e-82f9-f9eb7b2cc7c4' class='xr-var-data-in' type='checkbox'><label for='data-f4dfe1b6-621f-434e-82f9-f9eb7b2cc7c4' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([[0., 0., 0., ..., 0., 0., 0.],\n",
        "       [0., 0., 0., ..., 0., 0., 0.],\n",
        "       [0., 0., 0., ..., 0., 0., 0.],\n",
        "       ...,\n",
        "       [0., 0., 0., ..., 0., 0., 0.],\n",
        "       [0., 0., 0., ..., 0., 0., 0.],\n",
-       "       [0., 0., 0., ..., 0., 0., 0.]])</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-95f88721-8797-4134-b266-454abf741ff2' class='xr-section-summary-in' type='checkbox'  checked><label for='section-95f88721-8797-4134-b266-454abf741ff2' class='xr-section-summary' >Data variables: <span>(1)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>density</span></div><div class='xr-var-dims'>(northing, easting)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>2.67e+03 2.67e+03 ... 2.67e+03</div><input id='attrs-c590523a-537e-4b05-a354-1b76e0ff8b73' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-c590523a-537e-4b05-a354-1b76e0ff8b73' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-95942fa8-d30c-4d47-b1f6-1e0361ba259e' class='xr-var-data-in' type='checkbox'><label for='data-95942fa8-d30c-4d47-b1f6-1e0361ba259e' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([[2670., 2670., 2670., ..., 2670., 2670., 2670.],\n",
+       "       [0., 0., 0., ..., 0., 0., 0.]])</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-b7a16612-8ca7-4845-b739-609c66811be8' class='xr-section-summary-in' type='checkbox'  checked><label for='section-b7a16612-8ca7-4845-b739-609c66811be8' class='xr-section-summary' >Data variables: <span>(1)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>density</span></div><div class='xr-var-dims'>(northing, easting)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>2.67e+03 2.67e+03 ... 2.67e+03</div><input id='attrs-434b6891-28e3-4fdb-abc8-f0c1f2fc7c10' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-434b6891-28e3-4fdb-abc8-f0c1f2fc7c10' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-9cd1c7e9-f2e8-4d7f-b716-01e97d8d727c' class='xr-var-data-in' type='checkbox'><label for='data-9cd1c7e9-f2e8-4d7f-b716-01e97d8d727c' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([[2670., 2670., 2670., ..., 2670., 2670., 2670.],\n",
        "       [2670., 2670., 2670., ..., 2670., 2670., 2670.],\n",
        "       [2670., 2670., 2670., ..., 2670., 2670., 2670.],\n",
        "       ...,\n",
        "       [2670., 2670., 2670., ..., 2670., 2670., 2670.],\n",
        "       [2670., 2670., 2670., ..., 2670., 2670., 2670.],\n",
-       "       [2670., 2670., 2670., ..., 2670., 2670., 2670.]])</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-50eedc00-042a-4f47-8b46-b15ca8292c61' class='xr-section-summary-in' type='checkbox'  checked><label for='section-50eedc00-042a-4f47-8b46-b15ca8292c61' class='xr-section-summary' >Attributes: <span>(2)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>coords_units :</span></dt><dd>meters</dd><dt><span>properties_units :</span></dt><dd>SI</dd></dl></div></li></ul></div></div>"
+       "       [2670., 2670., 2670., ..., 2670., 2670., 2670.]])</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-6fedf26f-9115-42b2-b223-14b9dc4abdd5' class='xr-section-summary-in' type='checkbox'  checked><label for='section-6fedf26f-9115-42b2-b223-14b9dc4abdd5' class='xr-section-summary' >Attributes: <span>(2)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>coords_units :</span></dt><dd>meters</dd><dt><span>properties_units :</span></dt><dd>SI</dd></dl></div></li></ul></div></div>"
       ],
       "text/plain": [
        "<xarray.Dataset>\n",
@@ -2688,7 +2719,7 @@
    ],
    "source": [
     "# Create the prisms xarray.Dataset from the topography:\n",
-    "prisms_centers = (topo_plain.easting.values, topo_plain.northing.values)\n",
+    "prisms_centers = (topo_plain.easting, topo_plain.northing)\n",
     "surface = topo_plain.values\n",
     "density = 2670 * np.ones_like(surface) # assign density values to the prisms \n",
     "\n",
@@ -2703,6 +2734,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "5aa59989",
    "metadata": {},
    "source": [
     "### Compute the gravitational effect of the layer of prisms"
@@ -2711,11 +2743,12 @@
   {
    "cell_type": "code",
    "execution_count": 17,
+   "id": "824c2858",
    "metadata": {},
    "outputs": [],
    "source": [
     "# Define the coordinates where we are going to calculate the gravity effect of the prisms\n",
-    "coordinates = (data.easting.values, data.northing.values, data.elevation.values)\n",
+    "coordinates = (data.easting, data.northing, data.elevation)\n",
     "\n",
     "# Use the \"prism_layer\" accessor to compute gravity field of the layer\n",
     "result = topo_prisms.prism_layer.gravity(coordinates, field=\"g_z\")"
@@ -2723,6 +2756,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "4e5be90e",
    "metadata": {},
    "source": [
     "### Compute the Bouguer gravity disturbance"
@@ -2731,6 +2765,7 @@
   {
    "cell_type": "code",
    "execution_count": 18,
+   "id": "ed0425e2",
    "metadata": {},
    "outputs": [
     {
@@ -2937,6 +2972,7 @@
   {
    "cell_type": "code",
    "execution_count": 19,
+   "id": "09e339ef",
    "metadata": {},
    "outputs": [
     {
@@ -2964,6 +3000,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "ba11f466",
    "metadata": {
     "tags": []
    },
@@ -2979,6 +3016,7 @@
   {
    "cell_type": "code",
    "execution_count": 20,
+   "id": "120b2244",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2993,6 +3031,7 @@
   {
    "cell_type": "code",
    "execution_count": 21,
+   "id": "e3be62ae",
    "metadata": {},
    "outputs": [
     {
@@ -3209,6 +3248,7 @@
   {
    "cell_type": "code",
    "execution_count": 22,
+   "id": "6f30a590",
    "metadata": {},
    "outputs": [
     {
@@ -3236,6 +3276,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "050c5831",
    "metadata": {},
    "source": [
     "## Grid the residuals\n",
@@ -3252,6 +3293,7 @@
   {
    "cell_type": "code",
    "execution_count": 23,
+   "id": "7f1d7930",
    "metadata": {},
    "outputs": [
     {
@@ -3270,12 +3312,13 @@
     "eql = hm.EQLHarmonic(damping=1e2, relative_depth=5e3)  # The damping parameter helps smooth the predicted data and ensure stability.\n",
     "\n",
     "# Fit the layer coefficients to the observed residual disturbance:\n",
-    "eql.fit(coordinates, data.bouguer_residuals.values)"
+    "eql.fit(coordinates, data.bouguer_residuals)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 24,
+   "id": "ddf936e3",
    "metadata": {},
    "outputs": [
     {
@@ -3296,6 +3339,7 @@
   {
    "cell_type": "code",
    "execution_count": 25,
+   "id": "98d975aa",
    "metadata": {},
    "outputs": [
     {
@@ -3661,13 +3705,13 @@
        "Data variables:\n",
        "    bouguer_residuals  (latitude, longitude) float64 -1.207 -1.219 ... 11.62\n",
        "Attributes:\n",
-       "    metadata:  Generated by EQLHarmonic(damping=100.0, relative_depth=5000.0)</pre><div class='xr-wrap' hidden><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-7e427547-4d0d-4b22-b782-2e2af6fba999' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-7e427547-4d0d-4b22-b782-2e2af6fba999' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>latitude</span>: 401</li><li><span class='xr-has-index'>longitude</span>: 701</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-cb1161d6-d924-4aa7-a5e7-0685afcd3856' class='xr-section-summary-in' type='checkbox'  checked><label for='section-cb1161d6-d924-4aa7-a5e7-0685afcd3856' class='xr-section-summary' >Coordinates: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>longitude</span></div><div class='xr-var-dims'>(longitude)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>25.0 25.01 25.02 ... 31.99 32.0</div><input id='attrs-95eea50e-cca0-465c-97e4-b71e834f4f09' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-95eea50e-cca0-465c-97e4-b71e834f4f09' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-af85b904-08d4-42b1-8000-ea34643ac21e' class='xr-var-data-in' type='checkbox'><label for='data-af85b904-08d4-42b1-8000-ea34643ac21e' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([25.  , 25.01, 25.02, ..., 31.98, 31.99, 32.  ])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>latitude</span></div><div class='xr-var-dims'>(latitude)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>-27.0 -26.99 ... -23.01 -23.0</div><input id='attrs-41553ee8-5fcf-4e97-bb07-3e448ede87bd' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-41553ee8-5fcf-4e97-bb07-3e448ede87bd' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-5796b4f8-f950-4814-9fff-7e83631fbc44' class='xr-var-data-in' type='checkbox'><label for='data-5796b4f8-f950-4814-9fff-7e83631fbc44' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([-27.  , -26.99, -26.98, ..., -23.02, -23.01, -23.  ])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>upward</span></div><div class='xr-var-dims'>(latitude, longitude)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>2.2e+03 2.2e+03 ... 2.2e+03 2.2e+03</div><input id='attrs-2ec4d5f3-4d38-4f16-a44a-14ece9d3f67e' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-2ec4d5f3-4d38-4f16-a44a-14ece9d3f67e' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-95dcf2f1-65b7-46a2-8747-e7b4e1c8d915' class='xr-var-data-in' type='checkbox'><label for='data-95dcf2f1-65b7-46a2-8747-e7b4e1c8d915' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([[2200., 2200., 2200., ..., 2200., 2200., 2200.],\n",
+       "    metadata:  Generated by EQLHarmonic(damping=100.0, relative_depth=5000.0)</pre><div class='xr-wrap' hidden><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-376961b2-0fc6-4db1-ab21-4ee3d711f69d' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-376961b2-0fc6-4db1-ab21-4ee3d711f69d' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>latitude</span>: 401</li><li><span class='xr-has-index'>longitude</span>: 701</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-af19dc58-99be-45fa-a2f8-e3228647a56b' class='xr-section-summary-in' type='checkbox'  checked><label for='section-af19dc58-99be-45fa-a2f8-e3228647a56b' class='xr-section-summary' >Coordinates: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>longitude</span></div><div class='xr-var-dims'>(longitude)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>25.0 25.01 25.02 ... 31.99 32.0</div><input id='attrs-821c868c-f197-4a60-a875-50bd5cd080a1' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-821c868c-f197-4a60-a875-50bd5cd080a1' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-7419dff2-f163-4fe2-a639-40a8e560c783' class='xr-var-data-in' type='checkbox'><label for='data-7419dff2-f163-4fe2-a639-40a8e560c783' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([25.  , 25.01, 25.02, ..., 31.98, 31.99, 32.  ])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>latitude</span></div><div class='xr-var-dims'>(latitude)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>-27.0 -26.99 ... -23.01 -23.0</div><input id='attrs-eac399b5-a1c5-4637-914b-742046af5a29' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-eac399b5-a1c5-4637-914b-742046af5a29' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-693959e8-5be5-4505-ac94-3563b1b0125d' class='xr-var-data-in' type='checkbox'><label for='data-693959e8-5be5-4505-ac94-3563b1b0125d' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([-27.  , -26.99, -26.98, ..., -23.02, -23.01, -23.  ])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>upward</span></div><div class='xr-var-dims'>(latitude, longitude)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>2.2e+03 2.2e+03 ... 2.2e+03 2.2e+03</div><input id='attrs-c11506b1-5f46-452a-b89c-57ae46446a21' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-c11506b1-5f46-452a-b89c-57ae46446a21' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-21c933d1-b416-4265-a757-442e84f43523' class='xr-var-data-in' type='checkbox'><label for='data-21c933d1-b416-4265-a757-442e84f43523' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([[2200., 2200., 2200., ..., 2200., 2200., 2200.],\n",
        "       [2200., 2200., 2200., ..., 2200., 2200., 2200.],\n",
        "       [2200., 2200., 2200., ..., 2200., 2200., 2200.],\n",
        "       ...,\n",
        "       [2200., 2200., 2200., ..., 2200., 2200., 2200.],\n",
        "       [2200., 2200., 2200., ..., 2200., 2200., 2200.],\n",
-       "       [2200., 2200., 2200., ..., 2200., 2200., 2200.]])</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-aa7e7a88-b68c-4b39-863d-134e48a060be' class='xr-section-summary-in' type='checkbox'  checked><label for='section-aa7e7a88-b68c-4b39-863d-134e48a060be' class='xr-section-summary' >Data variables: <span>(1)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>bouguer_residuals</span></div><div class='xr-var-dims'>(latitude, longitude)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>-1.207 -1.219 -1.23 ... 11.73 11.62</div><input id='attrs-d934ddcb-a767-4d97-ad54-9639b6cc8706' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-d934ddcb-a767-4d97-ad54-9639b6cc8706' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-5642e5df-1085-42c9-94ef-2bdb86bddd2a' class='xr-var-data-in' type='checkbox'><label for='data-5642e5df-1085-42c9-94ef-2bdb86bddd2a' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>metadata :</span></dt><dd>Generated by EQLHarmonic(damping=100.0, relative_depth=5000.0)</dd></dl></div><div class='xr-var-data'><pre>array([[-1.20675143, -1.21882793, -1.22999708, ..., 65.99685818,\n",
+       "       [2200., 2200., 2200., ..., 2200., 2200., 2200.]])</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-54e3892d-ff99-4cc0-8177-abc0456c63ec' class='xr-section-summary-in' type='checkbox'  checked><label for='section-54e3892d-ff99-4cc0-8177-abc0456c63ec' class='xr-section-summary' >Data variables: <span>(1)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>bouguer_residuals</span></div><div class='xr-var-dims'>(latitude, longitude)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>-1.207 -1.219 -1.23 ... 11.73 11.62</div><input id='attrs-c586d2c7-f748-4a40-bcad-f378e18d211d' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-c586d2c7-f748-4a40-bcad-f378e18d211d' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-fcdb2bcf-3e0a-47b7-a503-2a0daafb2637' class='xr-var-data-in' type='checkbox'><label for='data-fcdb2bcf-3e0a-47b7-a503-2a0daafb2637' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>metadata :</span></dt><dd>Generated by EQLHarmonic(damping=100.0, relative_depth=5000.0)</dd></dl></div><div class='xr-var-data'><pre>array([[-1.20675143, -1.21882793, -1.22999708, ..., 65.99685818,\n",
        "        65.01473283, 63.81860947],\n",
        "       [-1.24604722, -1.25910475, -1.27123851, ..., 70.11061655,\n",
        "        68.88235041, 67.41414103],\n",
@@ -3679,7 +3723,7 @@
        "       [-1.08673798, -1.10014367, -1.11365469, ..., 11.94727357,\n",
        "        11.8274332 , 11.71101964],\n",
        "       [-1.07641269, -1.08966276, -1.10301605, ..., 11.84895372,\n",
-       "        11.73219916, 11.618686  ]])</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-065a9bd0-5d9f-453d-bf62-d423679f1b19' class='xr-section-summary-in' type='checkbox'  checked><label for='section-065a9bd0-5d9f-453d-bf62-d423679f1b19' class='xr-section-summary' >Attributes: <span>(1)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>metadata :</span></dt><dd>Generated by EQLHarmonic(damping=100.0, relative_depth=5000.0)</dd></dl></div></li></ul></div></div>"
+       "        11.73219916, 11.618686  ]])</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-19baa5e3-41d4-43ef-98c0-bb59ea945f73' class='xr-section-summary-in' type='checkbox'  checked><label for='section-19baa5e3-41d4-43ef-98c0-bb59ea945f73' class='xr-section-summary' >Attributes: <span>(1)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>metadata :</span></dt><dd>Generated by EQLHarmonic(damping=100.0, relative_depth=5000.0)</dd></dl></div></li></ul></div></div>"
       ],
       "text/plain": [
        "<xarray.Dataset>\n",
@@ -3715,6 +3759,7 @@
   {
    "cell_type": "code",
    "execution_count": 26,
+   "id": "551bad5f",
    "metadata": {},
    "outputs": [
     {
@@ -3739,6 +3784,7 @@
   {
    "cell_type": "code",
    "execution_count": 27,
+   "id": "c51d0ea2",
    "metadata": {},
    "outputs": [
     {
@@ -4104,19 +4150,19 @@
        "Data variables:\n",
        "    bouguer_residuals  (latitude, longitude) float64 nan nan nan ... nan nan nan\n",
        "Attributes:\n",
-       "    metadata:  Generated by EQLHarmonic(damping=100.0, relative_depth=5000.0)</pre><div class='xr-wrap' hidden><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-309e8899-fdea-495b-8259-219ea8528f9d' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-309e8899-fdea-495b-8259-219ea8528f9d' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>latitude</span>: 401</li><li><span class='xr-has-index'>longitude</span>: 701</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-8e765daa-ca1f-4199-9902-65a68672e8b4' class='xr-section-summary-in' type='checkbox'  checked><label for='section-8e765daa-ca1f-4199-9902-65a68672e8b4' class='xr-section-summary' >Coordinates: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>longitude</span></div><div class='xr-var-dims'>(longitude)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>25.0 25.01 25.02 ... 31.99 32.0</div><input id='attrs-89ca1990-575b-4e5c-8616-6f499d4516d5' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-89ca1990-575b-4e5c-8616-6f499d4516d5' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-4aa525ed-1c36-465c-bd8c-da9662c26aaf' class='xr-var-data-in' type='checkbox'><label for='data-4aa525ed-1c36-465c-bd8c-da9662c26aaf' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([25.  , 25.01, 25.02, ..., 31.98, 31.99, 32.  ])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>latitude</span></div><div class='xr-var-dims'>(latitude)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>-27.0 -26.99 ... -23.01 -23.0</div><input id='attrs-79e25028-dcda-4c5e-bf63-b264707be313' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-79e25028-dcda-4c5e-bf63-b264707be313' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-fd58b645-4050-4d78-a43a-aeb711614419' class='xr-var-data-in' type='checkbox'><label for='data-fd58b645-4050-4d78-a43a-aeb711614419' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([-27.  , -26.99, -26.98, ..., -23.02, -23.01, -23.  ])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>upward</span></div><div class='xr-var-dims'>(latitude, longitude)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>2.2e+03 2.2e+03 ... 2.2e+03 2.2e+03</div><input id='attrs-e1f4049e-f189-4c23-ba43-c0311cb3840d' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-e1f4049e-f189-4c23-ba43-c0311cb3840d' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-8815ca6b-70d0-4a56-98f7-d4458e5d806d' class='xr-var-data-in' type='checkbox'><label for='data-8815ca6b-70d0-4a56-98f7-d4458e5d806d' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([[2200., 2200., 2200., ..., 2200., 2200., 2200.],\n",
+       "    metadata:  Generated by EQLHarmonic(damping=100.0, relative_depth=5000.0)</pre><div class='xr-wrap' hidden><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-700aa653-cc7a-441a-aab4-49af6389d90d' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-700aa653-cc7a-441a-aab4-49af6389d90d' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>latitude</span>: 401</li><li><span class='xr-has-index'>longitude</span>: 701</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-ae2e4260-97ef-42a8-8fb8-8a6f8896ec1b' class='xr-section-summary-in' type='checkbox'  checked><label for='section-ae2e4260-97ef-42a8-8fb8-8a6f8896ec1b' class='xr-section-summary' >Coordinates: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>longitude</span></div><div class='xr-var-dims'>(longitude)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>25.0 25.01 25.02 ... 31.99 32.0</div><input id='attrs-2265992f-a17c-40a1-9c13-dd1dd5de590f' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-2265992f-a17c-40a1-9c13-dd1dd5de590f' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-9f585ff1-dca2-497d-bffe-83f37d87c047' class='xr-var-data-in' type='checkbox'><label for='data-9f585ff1-dca2-497d-bffe-83f37d87c047' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([25.  , 25.01, 25.02, ..., 31.98, 31.99, 32.  ])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>latitude</span></div><div class='xr-var-dims'>(latitude)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>-27.0 -26.99 ... -23.01 -23.0</div><input id='attrs-5db3a4f8-49b4-41c4-9da9-a0662eaa93f7' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-5db3a4f8-49b4-41c4-9da9-a0662eaa93f7' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-1f7e6d22-5984-4631-8fdb-bb2bcd0b8771' class='xr-var-data-in' type='checkbox'><label for='data-1f7e6d22-5984-4631-8fdb-bb2bcd0b8771' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([-27.  , -26.99, -26.98, ..., -23.02, -23.01, -23.  ])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>upward</span></div><div class='xr-var-dims'>(latitude, longitude)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>2.2e+03 2.2e+03 ... 2.2e+03 2.2e+03</div><input id='attrs-12d4e99a-87f0-4a07-8caa-369f3c35b766' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-12d4e99a-87f0-4a07-8caa-369f3c35b766' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-83c29198-7c51-4372-a47c-e1a68c02f8b8' class='xr-var-data-in' type='checkbox'><label for='data-83c29198-7c51-4372-a47c-e1a68c02f8b8' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([[2200., 2200., 2200., ..., 2200., 2200., 2200.],\n",
        "       [2200., 2200., 2200., ..., 2200., 2200., 2200.],\n",
        "       [2200., 2200., 2200., ..., 2200., 2200., 2200.],\n",
        "       ...,\n",
        "       [2200., 2200., 2200., ..., 2200., 2200., 2200.],\n",
        "       [2200., 2200., 2200., ..., 2200., 2200., 2200.],\n",
-       "       [2200., 2200., 2200., ..., 2200., 2200., 2200.]])</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-403f543a-e7f0-45eb-8a2a-d6d48ec6d3f9' class='xr-section-summary-in' type='checkbox'  checked><label for='section-403f543a-e7f0-45eb-8a2a-d6d48ec6d3f9' class='xr-section-summary' >Data variables: <span>(1)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>bouguer_residuals</span></div><div class='xr-var-dims'>(latitude, longitude)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>nan nan nan nan ... nan nan nan nan</div><input id='attrs-2d669e24-aedc-43ff-853b-592b6b25b36a' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-2d669e24-aedc-43ff-853b-592b6b25b36a' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-bef6e845-a541-49ef-8a5a-100b6fd9c6a4' class='xr-var-data-in' type='checkbox'><label for='data-bef6e845-a541-49ef-8a5a-100b6fd9c6a4' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>metadata :</span></dt><dd>Generated by EQLHarmonic(damping=100.0, relative_depth=5000.0)</dd></dl></div><div class='xr-var-data'><pre>array([[nan, nan, nan, ..., nan, nan, nan],\n",
+       "       [2200., 2200., 2200., ..., 2200., 2200., 2200.]])</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-7b1fee70-dcf9-46ce-8dbe-9e36d83437aa' class='xr-section-summary-in' type='checkbox'  checked><label for='section-7b1fee70-dcf9-46ce-8dbe-9e36d83437aa' class='xr-section-summary' >Data variables: <span>(1)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>bouguer_residuals</span></div><div class='xr-var-dims'>(latitude, longitude)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>nan nan nan nan ... nan nan nan nan</div><input id='attrs-297f0f35-a64f-474d-9344-5971b16a7bdc' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-297f0f35-a64f-474d-9344-5971b16a7bdc' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-1ee6f3d4-16e4-4fe2-a4c8-da95011cda4b' class='xr-var-data-in' type='checkbox'><label for='data-1ee6f3d4-16e4-4fe2-a4c8-da95011cda4b' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>metadata :</span></dt><dd>Generated by EQLHarmonic(damping=100.0, relative_depth=5000.0)</dd></dl></div><div class='xr-var-data'><pre>array([[nan, nan, nan, ..., nan, nan, nan],\n",
        "       [nan, nan, nan, ..., nan, nan, nan],\n",
        "       [nan, nan, nan, ..., nan, nan, nan],\n",
        "       ...,\n",
        "       [nan, nan, nan, ..., nan, nan, nan],\n",
        "       [nan, nan, nan, ..., nan, nan, nan],\n",
-       "       [nan, nan, nan, ..., nan, nan, nan]])</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-af85461d-2072-4434-b221-3642315bd74f' class='xr-section-summary-in' type='checkbox'  checked><label for='section-af85461d-2072-4434-b221-3642315bd74f' class='xr-section-summary' >Attributes: <span>(1)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>metadata :</span></dt><dd>Generated by EQLHarmonic(damping=100.0, relative_depth=5000.0)</dd></dl></div></li></ul></div></div>"
+       "       [nan, nan, nan, ..., nan, nan, nan]])</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-e0fd8934-bfa6-450d-8e0e-319ef7519bb5' class='xr-section-summary-in' type='checkbox'  checked><label for='section-e0fd8934-bfa6-450d-8e0e-319ef7519bb5' class='xr-section-summary' >Attributes: <span>(1)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>metadata :</span></dt><dd>Generated by EQLHarmonic(damping=100.0, relative_depth=5000.0)</dd></dl></div></li></ul></div></div>"
       ],
       "text/plain": [
        "<xarray.Dataset>\n",
@@ -4138,13 +4184,14 @@
    ],
    "source": [
     "# Mask grid points that are outside the convex hull of the given data points:\n",
-    "grid = vd.convexhull_mask(data_coordinates=(data.longitude.values, data.latitude.values), grid=grid)\n",
+    "grid = vd.convexhull_mask(data_coordinates=(data.longitude, data.latitude), grid=grid)\n",
     "grid"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 28,
+   "id": "1c9a44bb",
    "metadata": {},
    "outputs": [
     {
@@ -4168,6 +4215,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "bdc2a882",
    "metadata": {},
    "source": [
     "<img src=\"img/study-area.png\">"
@@ -4175,6 +4223,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "1a61b850",
    "metadata": {},
    "source": [
     "## Extract a profile\n",
@@ -4185,6 +4234,7 @@
   {
    "cell_type": "code",
    "execution_count": 29,
+   "id": "314d90dd",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4195,6 +4245,7 @@
   {
    "cell_type": "code",
    "execution_count": 30,
+   "id": "946cd11c",
    "metadata": {},
    "outputs": [
     {
@@ -4220,6 +4271,7 @@
   {
    "cell_type": "code",
    "execution_count": 31,
+   "id": "3e6a3103",
    "metadata": {},
    "outputs": [
     {
@@ -4382,6 +4434,7 @@
   {
    "cell_type": "code",
    "execution_count": 32,
+   "id": "02e0791e",
    "metadata": {},
    "outputs": [
     {
@@ -4409,6 +4462,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "89b4d32d",
    "metadata": {},
    "source": [
     "## Save results"
@@ -4417,6 +4471,7 @@
   {
    "cell_type": "code",
    "execution_count": 33,
+   "id": "fe932f36",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4426,6 +4481,7 @@
   {
    "cell_type": "code",
    "execution_count": 34,
+   "id": "c3e8fa7f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4449,7 +4505,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.6"
+   "version": "3.9.2"
   },
   "toc-autonumbering": true,
   "toc-showcode": false,


### PR DESCRIPTION
Remove unneeded `.values` from `DataFrame`s and `DataArray`s in notebooks and
in `test_install.py`.


Fixes #28 


**Reminders**:

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst` and the base `__init__.py` file for the package.
- [ ] Write detailed docstrings for all functions/classes/methods. It often helps to design better code if you write the docstrings first.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
- [ ] Add your full name, affiliation, and [ORCID](https://orcid.org) (optional) to the `AUTHORS.md` file (if you haven't already) in case you'd like to be listed as an author on the [Zenodo](https://zenodo.org/communities/fatiando) archive of the next release.
